### PR TITLE
🛡️ Sentinel: [CRITICAL/MEDIUM] Fix X.509 SKID bug and AES side-effect

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -23,3 +23,12 @@
 **Vulnerability:** The password verification logic allowed the iteration count to be parsed directly from the hash string without any upper bound. An attacker could provide a hash with a very large iteration count (e.g., millions), causing the server to consume excessive CPU resources.
 **Learning:** While password hashing is intended to be slow, allowing the input to arbitrarily increase the work factor leads to resource exhaustion vulnerabilities.
 **Prevention:** Always enforce a reasonable maximum iteration count (e.g., 1,000,000) when parsing cryptographic parameters from untrusted input.
+## 2025-05-22 - [Incorrect use of Hash.Sum]
+**Vulnerability:** X509CertSubjectKeyID was incorrectly calculating the Subject Key Identifier (SKID) by hashing an empty string instead of the public key.
+**Learning:** Go's `hash.Hash.Sum(b []byte)` appends the current hash to `b` and returns the resulting slice. It does NOT hash `b`. To hash data, one must use `hasher.Write(data)`.
+**Prevention:** Always use `hasher.Write(data)` before calling `hasher.Sum(nil)`.
+
+## 2025-05-22 - [Side effects of append on input slices]
+**Vulnerability:** `AEADDecryptBasic` was using `append(ciphertext, tag...)` which could modify the underlying array of the input `ciphertext` slice if it had extra capacity.
+**Learning:** In Go, `append` can be in-place if there is enough capacity. This can lead to unexpected side effects on the caller's data.
+**Prevention:** Concatenate into a new slice or use a local copy when modifying input slices that shouldn't be changed.

--- a/crypto/aes.go
+++ b/crypto/aes.go
@@ -185,7 +185,10 @@ func AEADDecryptBasic(key, ciphertext, iv, tag, additionalData []byte) (plaintex
 		return nil, errors.Errorf("iv size not match")
 	}
 
-	plaintext, err = gcm.Open(nil, iv, append(ciphertext, tag...), additionalData)
+	combined := make([]byte, 0, len(ciphertext)+len(tag))
+	combined = append(combined, ciphertext...)
+	combined = append(combined, tag...)
+	plaintext, err = gcm.Open(nil, iv, combined, additionalData)
 	if err != nil {
 		return nil, errors.Wrap(err, "gcm decrypt")
 	}

--- a/crypto/x509.go
+++ b/crypto/x509.go
@@ -1576,11 +1576,11 @@ func ReadableOIDs(oids []asn1.ObjectIdentifier) (names []string) {
 func X509CertSubjectKeyID(pubkey crypto.PublicKey) ([]byte, error) {
 	keyBytes, err := Pubkey2Der(pubkey)
 	if err != nil {
-		return nil, errors.Wrap(err, "marshal pubkeu")
+		return nil, errors.Wrap(err, "marshal pubkey")
 	}
 
 	hasher := sha1.New()
-	hasher.Sum(keyBytes)
+	hasher.Write(keyBytes)
 	return hasher.Sum(nil), nil
 }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL/MEDIUM

💡 Vulnerability: 
1. X.509 SubjectKeyID was incorrectly calculated by hashing an empty string instead of the public key DER bytes.
2. AES GCM decryption (AEADDecryptBasic) was using append on an input slice, which could modify the caller's buffer if it had extra capacity.

🎯 Impact:
1. Incorrect SubjectKeyID can cause failures in certificate path building and validation.
2. Unexpected buffer mutation can lead to data integrity issues or race conditions in calling code.

🔧 Fix:
1. Corrected SKID calculation to use hasher.Write(keyBytes).
2. Modified AEADDecryptBasic to concatenate ciphertext and tag into a new slice.
3. Corrected a typo in an error message.

✅ Verification: Confirmed fix with a reproduction test case and ensured no regressions via go test ./...

---
*PR created automatically by Jules for task [7933698877234531468](https://jules.google.com/task/7933698877234531468) started by @Laisky*