### PR TITLE
🛡️ Sentinel: Fix incorrect hash calculation in HashXxhashString

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -33,12 +33,13 @@ func HashSHA256String(val string) string {
 	return hex.EncodeToString(b[:])
 }
 
-// HashXxhashString calculate string's hash by sha256
+// HashXxhashString calculate string's hash by xxhash
 //
 // Deprecated: use Hash instead
 func HashXxhashString(val string) string {
-	b := xxhash.New().Sum([]byte(val))
-	return hex.EncodeToString(b)
+	h := xxhash.New()
+	_, _ = h.Write([]byte(val))
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // HashTypeInterface hashs

--- a/hash_test.go
+++ b/hash_test.go
@@ -59,7 +59,7 @@ func TestHashXxhashString(t *testing.T) {
 	t.Parallel()
 	val := testhashraw
 	got := HashXxhashString(val)
-	if got != "6466696a3369666a326a6a6c326a656c6b6a646b776566ef46db3751d8e999" {
+	if got != "cbd2efc89af5217d" {
 		t.Fatalf("got: %v", got)
 	}
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Misuse of Go's 'hash.Hash.Sum' interface in 'HashXxhashString'.
🎯 Impact: Incorrect and weak hashing where input data was not actually hashed, compromising data integrity checks.
🔧 Fix: Used 'h.Write([]byte(val))' and 'h.Sum(nil)' for correct hashing.
✅ Verification: Updated unit tests in 'hash_test.go' and verified all tests pass.

---
*PR created automatically by Jules for task [10492841751317385842](https://jules.google.com/task/10492841751317385842) started by @Laisky*