### PR TITLE
🛡️ Sentinel: [MEDIUM] Enforce maximum password length in crypto package

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -23,3 +23,8 @@
 **Vulnerability:** The password verification logic allowed the iteration count to be parsed directly from the hash string without any upper bound. An attacker could provide a hash with a very large iteration count (e.g., millions), causing the server to consume excessive CPU resources.
 **Learning:** While password hashing is intended to be slow, allowing the input to arbitrarily increase the work factor leads to resource exhaustion vulnerabilities.
 **Prevention:** Always enforce a reasonable maximum iteration count (e.g., 1,000,000) when parsing cryptographic parameters from untrusted input.
+
+## 2026-05-22 - Password Hashing Denial of Service (Length)
+**Vulnerability:** Lack of maximum password length limit allowed for CPU-exhaustion Denial of Service (DoS) attacks when combined with iterative hashing.
+**Learning:** Even with iteration count limits, very large input passwords can still consume excessive CPU during the hashing process.
+**Prevention:** Enforce a strict upper limit on password length (e.g., 1024 bytes) before starting any iterative hashing operations.

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -39,6 +39,8 @@ const (
 	DefaultPasswordDelay = 2 * time.Second
 	// MaxPasswordHashIteration limit max hash iteration count
 	MaxPasswordHashIteration = 1000000
+	// MaxPasswordLength limit max password length to prevent DoS
+	MaxPasswordLength = 1024
 	// MinPasswordHashIteration limit min hash iteration count
 	MinPasswordHashIteration = 10000
 	// legacyMinPasswordHashIteration keeps compatibility for already stored hashes.
@@ -146,6 +148,8 @@ func parseHashedPassword(hashedString string) (h HashedPassword, err error) {
 func VerifyHashedPassword(rawpassword []byte, hashedPassword string) (err error) {
 	if len(rawpassword) == 0 || len(hashedPassword) == 0 {
 		return errors.Errorf("rawpassword or hashedPassword is empty")
+	} else if len(rawpassword) > MaxPasswordLength {
+		return errors.Errorf("password is too long")
 	}
 
 	defer gutils.NewDelay(DefaultPasswordDelay).Wait()
@@ -182,6 +186,8 @@ func VerifyHashedPassword(rawpassword []byte, hashedPassword string) (err error)
 func PasswordHash(password []byte, hasher gutils.HashType) (hashedPassword string, err error) {
 	if len(password) == 0 {
 		return "", errors.Errorf("password is empty")
+	} else if len(password) > MaxPasswordLength {
+		return "", errors.Errorf("password is too long")
 	}
 
 	defer gutils.NewDelay(DefaultPasswordDelay).Wait()

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -165,3 +165,18 @@ func TestVerifyHashedPassword_DoS(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "too many iterations")
 }
+
+func TestVerifyHashedPassword_PasswordTooLong(t *testing.T) {
+	t.Parallel()
+	longPassword := make([]byte, MaxPasswordLength+1)
+	_, err := rand.Read(longPassword)
+	require.NoError(t, err)
+
+	_, err = PasswordHash(longPassword, gutils.HashTypeSha256)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "password is too long")
+
+	err = VerifyHashedPassword(longPassword, "some-hash")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "password is too long")
+}


### PR DESCRIPTION
Vulnerability: Lack of maximum password length limit allowed for CPU-exhaustion Denial of Service (DoS) attacks when combined with iterative hashing.
Impact: An attacker could send an extremely long password, causing the server to consume excessive CPU resources during the iterative hashing process (up to 1,000,000 iterations).
Fix: Added a MaxPasswordLength constant (1024 bytes) and enforced it in PasswordHash and VerifyHashedPassword.
Verification: Added TestVerifyHashedPassword_PasswordTooLong to crypto/crypto_test.go and verified that all tests pass.

---
*PR created automatically by Jules for task [18123931881593834612](https://jules.google.com/task/18123931881593834612) started by @Laisky*