### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability in HTTP response handling

### DIFF
--- a/agents/files/mcp_client.go
+++ b/agents/files/mcp_client.go
@@ -254,7 +254,8 @@ func (client *MCPClient) doRPC(ctx context.Context, sessionID string, reqBody rp
 		_ = httpResp.Body.Close()
 	}()
 
-	respBody, err := io.ReadAll(httpResp.Body)
+	const maxRespBodyBytes = 4 * 1024 * 1024 // 4MB
+	respBody, err := io.ReadAll(io.LimitReader(httpResp.Body, maxRespBodyBytes))
 	if err != nil {
 		return errors.Wrap(err, "read response body")
 	}

--- a/http.go
+++ b/http.go
@@ -345,11 +345,23 @@ func RequestJSONWithClient(httpClient *http.Client,
 	defer func() { _ = r.Body.Close() }()
 
 	if r.StatusCode/100 != 2 { //nolint:usestdlibvars //"100" can be replaced by http.StatusContinue
-		respBytes, err := io.ReadAll(r.Body)
+		const maxHTTPErrorBodyBytes = 8192
+		respBytes, err := io.ReadAll(io.LimitReader(r.Body, maxHTTPErrorBodyBytes+1))
 		if err != nil {
 			return errors.Wrap(err, "try to read response data error")
 		}
-		return errors.New(string(respBytes[:]))
+
+		truncated := len(respBytes) > maxHTTPErrorBodyBytes
+		if truncated {
+			respBytes = respBytes[:maxHTTPErrorBodyBytes]
+		}
+
+		msg := string(respBytes)
+		if truncated {
+			msg += " (truncated)"
+		}
+
+		return errors.New(msg)
 	}
 
 	if err = json.NewDecoder(r.Body).Decode(resp); err != nil {

--- a/http_security_test.go
+++ b/http_security_test.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestJSON_DoS(t *testing.T) {
+	hugeSize := 10 * 1024 * 1024 // 10MB
+	hugeBody := strings.Repeat("a", hugeSize)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(hugeBody))
+	}))
+	defer server.Close()
+
+	var resp any
+	err := RequestJSON("GET", server.URL, nil, &resp)
+	require.Error(t, err)
+
+	// Now it should be truncated to 8192 + len(" (truncated)")
+	limit := 8192
+	expectedMaxLen := limit + len(" (truncated)")
+	if len(err.Error()) > expectedMaxLen {
+		t.Errorf("Expected error message to be at most %d bytes, got %d", expectedMaxLen, len(err.Error()))
+	}
+	require.Contains(t, err.Error(), "(truncated)")
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: HTTP response bodies were being read entirely into memory without size limits in `RequestJSON` error handling and MCP JSON-RPC responses.
🎯 Impact: A malicious or misconfigured server could send a massive response body, causing the client to crash with an Out of Memory (OOM) error (Denial of Service).
🔧 Fix: Implemented `io.LimitReader` to enforce strict size limits (8KB for error messages, 4MB for MCP payloads). Added "(truncated)" suffix to error messages when truncation occurs.
✅ Verification: Added `http_security_test.go` confirming that a 10MB error response is correctly truncated. Verified all tests pass.

---
*PR created automatically by Jules for task [13420574406512059747](https://jules.google.com/task/13420574406512059747) started by @Laisky*