### PR TITLE
🛡️ Sentinel: Fix and secure OpenURLInDefaultBrowser

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,8 @@
 **Vulnerability:** HTTP error handling read the full remote response body into memory before wrapping the error message, allowing oversized payloads to amplify memory usage.
 **Learning:** Even non-success paths must enforce strict size limits because attackers can intentionally trigger and enlarge error responses.
 **Prevention:** Always read remote error payloads through `io.LimitReader` with a fixed cap and mark messages as truncated when the limit is exceeded.
+
+## 2026-06-15 - Unsafe URL Execution in Browser
+**Vulnerability:** `OpenURLInDefaultBrowser` lacked URL validation and scheme restriction, and on Windows/WSL used `cmd /c start` with improper argument order. This allowed for potential command injection via dangerous schemes (e.g., `file://`, `javascript:`) or shell-sensitive characters.
+**Learning:** Functions that invoke external commands with user-supplied strings must always validate and sanitize those strings. For URLs, parsing and whitelisting schemes is essential.
+**Prevention:** Always use `url.ParseRequestURI` to validate URLs and enforce a strict whitelist of allowed schemes (e.g., `http`, `https`, `mailto`). For shell commands like `start`, ensure the argument order is correct (e.g., providing an empty title string `""` to avoid misinterpretation of the URL as a title).

--- a/email/email_test.go
+++ b/email/email_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Laisky/errors/v2"
+
 	"github.com/Laisky/go-utils/v6/log"
 	"github.com/Laisky/go-utils/v6/mocks"
 )

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932
 	github.com/google/uuid v1.6.0
 	github.com/json-iterator/go v1.1.12
+	github.com/klauspost/compress v1.18.4
 	github.com/klauspost/pgzip v1.2.6
 	github.com/monnand/dhkx v0.0.0-20180522003156-9e5b033f1ac4
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
@@ -43,7 +44,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/klauspost/compress v1.18.4 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/http.go
+++ b/http.go
@@ -34,8 +34,8 @@ func (k CtxKey) String() string {
 }
 
 const (
-	defaultHTTPClientOptTimeout = 30 * time.Second
-	defaultHTTPClientOptMaxConn = 20
+	defaultHTTPClientOptTimeout  = 30 * time.Second
+	defaultHTTPClientOptMaxConn  = 20
 	maxRequestJSONErrorBodyBytes = 8 * 1024
 
 	// HTTPHeaderHost HTTP header name
@@ -457,31 +457,40 @@ func checkRespErr(c *chaining.Chain) (any, error) {
 // Inspired by https://gist.github.com/sevkin/9798d67b2cb9d07cb05f89f14ba682f8?permalink_comment_id=5019685#gistcomment-5019685
 //
 //nolint:lll
-func OpenURLInDefaultBrowser(ctx context.Context, url string) error {
+func OpenURLInDefaultBrowser(ctx context.Context, urlStr string) error {
+	u, err := url.ParseRequestURI(urlStr)
+	if err != nil {
+		return errors.Wrap(err, "invalid url")
+	}
+
+	switch u.Scheme {
+	case "http", "https", "mailto":
+		// allowed
+	default:
+		return errors.Errorf("unsupported scheme %q", u.Scheme)
+	}
+
 	var cmd string
 	var args []string
 
 	switch runtime.GOOS {
 	case "windows":
 		cmd = "cmd"
-		args = []string{"/c", "start"}
+		args = []string{"/c", "start", "", urlStr}
 	case "darwin":
 		cmd = "open"
+		args = []string{urlStr}
 	default: // "linux", "freebsd", "openbsd", "netbsd"
 		// Check if running under WSL
 		if isWSL(ctx) {
 			// Use 'cmd.exe /c start' to open the URL in the default Windows browser
 			cmd = "cmd.exe"
-			args = []string{"/c", "start", url}
+			args = []string{"/c", "start", "", urlStr}
 		} else {
 			// Use xdg-open on native Linux environments
 			cmd = "xdg-open"
-			args = []string{url}
+			args = []string{urlStr}
 		}
-	}
-	if len(args) > 1 {
-		// args[0] is used for 'start' command argument, to prevent issues with URLs starting with a quote
-		args = append(args[:1], append([]string{""}, args[1:]...)...)
 	}
 
 	//nolint:gosec //G204: Subprocess launched with variable

--- a/http_test.go
+++ b/http_test.go
@@ -1000,3 +1000,39 @@ func (r *streamReader) Read(p []byte) (n int, err error) {
 	r.pos += n
 	return n, nil
 }
+
+func TestOpenURLInDefaultBrowser_Security(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"valid_http", "http://example.com", false},
+		{"valid_https", "https://example.com", false},
+		{"valid_mailto", "mailto:someone@example.com", false},
+		{"invalid_url", "not-a-url", true},
+		{"unsupported_scheme_file", "file:///etc/passwd", true},
+		{"unsupported_scheme_javascript", "javascript:alert(1)", true},
+		{"unsupported_scheme_data", "data:text/plain,hello", true},
+		{"empty_url", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := OpenURLInDefaultBrowser(ctx, tt.url)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				// We don't want to actually run the command in most environments,
+				// but here we just check if it passes the validation phase.
+				// Since we're in Linux and might not have xdg-open, it might fail later.
+				// But we're mostly interested in the validation error.
+				if err != nil && (err.Error() == "invalid url" || strings.Contains(err.Error(), "unsupported scheme")) {
+					t.Errorf("Validation failed unexpectedly: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: OpenURLInDefaultBrowser was broken on Windows/Darwin (URL not passed) and vulnerable to potential command injection on Windows/WSL due to lack of URL validation and improper start command syntax.
🎯 Impact: On Windows/WSL, an attacker could potentially execute arbitrary commands if they could control the URL passed to this function. Also, the function didn't work on non-Linux systems.
🔧 Fix:
- Renamed parameter to urlStr to avoid shadowing.
- Added URL validation using url.ParseRequestURI.
- Restricted allowed schemes to http, https, and mailto.
- Fixed the OS-specific command construction and start command syntax.
✅ Verification: Added TestOpenURLInDefaultBrowser_Security and verified with go test.

---
*PR created automatically by Jules for task [4081272892398602248](https://jules.google.com/task/4081272892398602248) started by @Laisky*