### PR TITLE
🛡️ Sentinel: add size limit to JSON response decoding

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,9 @@
 **Vulnerability:** HTTP error handling read the full remote response body into memory before wrapping the error message, allowing oversized payloads to amplify memory usage.
 **Learning:** Even non-success paths must enforce strict size limits because attackers can intentionally trigger and enlarge error responses.
 **Prevention:** Always read remote error payloads through `io.LimitReader` with a fixed cap and mark messages as truncated when the limit is exceeded.
+
+## 2026-02-22 - Unbounded HTTP Response Body in JSON Decoding
+
+**Vulnerability:** The HTTP client utility for JSON requests decoded the response body without a size limit, potentially leading to memory exhaustion (DoS) if an attacker returns a very large JSON payload.
+**Learning:** High-level utilities that handle network responses must enforce limits even on "success" paths, as response content is untrusted data.
+**Prevention:** Always wrap response bodies with `io.LimitReader` before decoding or reading, even when the status code is 2xx.

--- a/agents/memory/interface.go
+++ b/agents/memory/interface.go
@@ -91,13 +91,13 @@ type Config struct {
 	//   - API base: https://host[/optional-prefix] or https://host[/optional-prefix]/v1
 	//   - host only: host or host:port (HTTPS is assumed automatically)
 	// The engine normalizes all forms to .../v1/responses.
-	LLMAPIBase             string
-	LLMAPIKey              string
-	LLMModel               string
-	LLMTimeout             time.Duration
-	LLMMaxOutputTokens     int
-	HeuristicClient        HeuristicClient
-	TimeNow                func() time.Time
+	LLMAPIBase         string
+	LLMAPIKey          string
+	LLMModel           string
+	LLMTimeout         time.Duration
+	LLMMaxOutputTokens int
+	HeuristicClient    HeuristicClient
+	TimeNow            func() time.Time
 }
 
 // StandardEngine is a storage-backed implementation of Engine.

--- a/email/email_test.go
+++ b/email/email_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Laisky/errors/v2"
+
 	"github.com/Laisky/go-utils/v6/log"
 	"github.com/Laisky/go-utils/v6/mocks"
 )

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932
 	github.com/google/uuid v1.6.0
 	github.com/json-iterator/go v1.1.12
+	github.com/klauspost/compress v1.18.4
 	github.com/klauspost/pgzip v1.2.6
 	github.com/monnand/dhkx v0.0.0-20180522003156-9e5b033f1ac4
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
@@ -43,7 +44,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/klauspost/compress v1.18.4 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/http.go
+++ b/http.go
@@ -40,9 +40,10 @@ func (k CtxKey) String() string {
 }
 
 const (
-	defaultHTTPClientOptTimeout = 30 * time.Second
-	defaultHTTPClientOptMaxConn = 20
+	defaultHTTPClientOptTimeout  = 30 * time.Second
+	defaultHTTPClientOptMaxConn  = 20
 	maxRequestJSONErrorBodyBytes = 8 * 1024
+	maxRequestJSONBodyBytes      = 8 * 1024 * 1024
 
 	// HTTPHeaderHost HTTP header name
 	HTTPHeaderHost = "Host"
@@ -370,7 +371,7 @@ func RequestJSONWithClient(httpClient *http.Client,
 		return errors.New(string(respBytes[:]))
 	}
 
-	if err = json.NewDecoder(r.Body).Decode(resp); err != nil {
+	if err = json.NewDecoder(io.LimitReader(r.Body, maxRequestJSONBodyBytes)).Decode(resp); err != nil {
 		return errors.Wrapf(err, "unmarshal response")
 	}
 

--- a/http_test.go
+++ b/http_test.go
@@ -1087,3 +1087,30 @@ func (r *streamReader) Read(p []byte) (n int, err error) {
 	r.pos += n
 	return n, nil
 }
+
+func TestRequestJSONWithClientLargeSuccessBodyIsLimited(t *testing.T) {
+	t.Parallel()
+
+	// Create a server that returns a very large response
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Return more than 8MB of data
+		// We'll return a large JSON object
+		_, _ = w.Write([]byte("{\"data\":\""))
+		largeData := strings.Repeat("x", 9*1024*1024) // 9MB
+		_, _ = w.Write([]byte(largeData))
+		_, _ = w.Write([]byte("\"}"))
+	}))
+	defer server.Close()
+
+	httpClient, err := NewHTTPClient(WithHTTPClientTimeout(5 * time.Second))
+	require.NoError(t, err)
+
+	var resp map[string]any
+	err = RequestJSONWithClient(httpClient, http.MethodGet, server.URL, nil, &resp)
+	require.Error(t, err)
+	// The error should be related to hitting the limit
+	// Since json.NewDecoder hits EOF earlier than expected
+	require.Contains(t, err.Error(), "unmarshal response")
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Unbounded memory usage when decoding JSON responses.
🎯 Impact: Potential Denial of Service (DoS) via memory exhaustion if a server returns an oversized payload.
🔧 Fix: Enforced an 8MB limit on successful JSON response bodies using io.LimitReader.
✅ Verification: Verified with TestRequestJSONWithClientLargeSuccessBodyIsLimited in http_test.go and full test suite.

---
*PR created automatically by Jules for task [13452765584286787157](https://jules.google.com/task/13452765584286787157) started by @Laisky*