### PR TITLE
🛡️ Sentinel: [MEDIUM] Mitigate timing side-channels and DoS risks in password hashing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,13 @@
 **Vulnerability:** HTTP error handling read the full remote response body into memory before wrapping the error message, allowing oversized payloads to amplify memory usage.
 **Learning:** Even non-success paths must enforce strict size limits because attackers can intentionally trigger and enlarge error responses.
 **Prevention:** Always read remote error payloads through `io.LimitReader` with a fixed cap and mark messages as truncated when the limit is exceeded.
+
+## 2026-02-22 - Timing Side-Channel in Password Validation
+**Vulnerability:** Input validation failures (empty/too long password) in authentication functions returned immediately without applying the configured artificial delay, allowing attackers to distinguish validation failures from incorrect credentials via timing.
+**Learning:** Security-critical delays must be initiated at the very entry of a function (via defer) to cover all exit paths, including early returns from basic input validation.
+**Prevention:** Always place `defer NewDelay(...).Wait()` at the top of security-sensitive functions.
+
+## 2026-02-22 - Unbounded String Parsing DoS
+**Vulnerability:** `VerifyHashedPassword` accepted `hashedPassword` strings of arbitrary length, which were processed using `strings.Split`. Extremely large inputs could lead to CPU and memory exhaustion.
+**Learning:** Even stored hashes or supposedly formatted strings must be length-limited if they come from untrusted input before any parsing occurs.
+**Prevention:** Enforce strict length limits (e.g., 4096 bytes) on all string inputs before calling resource-intensive parsing functions.

--- a/agents/memory/interface.go
+++ b/agents/memory/interface.go
@@ -91,13 +91,13 @@ type Config struct {
 	//   - API base: https://host[/optional-prefix] or https://host[/optional-prefix]/v1
 	//   - host only: host or host:port (HTTPS is assumed automatically)
 	// The engine normalizes all forms to .../v1/responses.
-	LLMAPIBase             string
-	LLMAPIKey              string
-	LLMModel               string
-	LLMTimeout             time.Duration
-	LLMMaxOutputTokens     int
-	HeuristicClient        HeuristicClient
-	TimeNow                func() time.Time
+	LLMAPIBase         string
+	LLMAPIKey          string
+	LLMModel           string
+	LLMTimeout         time.Duration
+	LLMMaxOutputTokens int
+	HeuristicClient    HeuristicClient
+	TimeNow            func() time.Time
 }
 
 // StandardEngine is a storage-backed implementation of Engine.

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -146,13 +146,16 @@ func parseHashedPassword(hashedString string) (h HashedPassword, err error) {
 
 // VerifyHashedPassword verify HashedPassword
 func VerifyHashedPassword(rawpassword []byte, hashedPassword string) (err error) {
+	defer gutils.NewDelay(DefaultPasswordDelay).Wait()
+	if len(hashedPassword) > 4096 {
+		return errors.Errorf("hashedPassword is too long")
+	}
+
 	if len(rawpassword) == 0 || len(hashedPassword) == 0 {
 		return errors.Errorf("rawpassword or hashedPassword is empty")
 	} else if len(rawpassword) > MaxPasswordLength {
 		return errors.Errorf("password is too long")
 	}
-
-	defer gutils.NewDelay(DefaultPasswordDelay).Wait()
 	hp, err := parseHashedPassword(hashedPassword)
 	if err != nil {
 		return errors.Wrap(err, "parse hashed password")
@@ -184,13 +187,12 @@ func VerifyHashedPassword(rawpassword []byte, hashedPassword string) (err error)
 
 // PasswordHash generate salted hash of password, can verify by VerifyHashedPassword
 func PasswordHash(password []byte, hasher gutils.HashType) (hashedPassword string, err error) {
+	defer gutils.NewDelay(DefaultPasswordDelay).Wait()
 	if len(password) == 0 {
 		return "", errors.Errorf("password is empty")
 	} else if len(password) > MaxPasswordLength {
 		return "", errors.Errorf("password is too long")
 	}
-
-	defer gutils.NewDelay(DefaultPasswordDelay).Wait()
 
 	var salt []byte
 	switch hasher {

--- a/email/email_test.go
+++ b/email/email_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Laisky/errors/v2"
+
 	"github.com/Laisky/go-utils/v6/log"
 	"github.com/Laisky/go-utils/v6/mocks"
 )

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932
 	github.com/google/uuid v1.6.0
 	github.com/json-iterator/go v1.1.12
+	github.com/klauspost/compress v1.18.4
 	github.com/klauspost/pgzip v1.2.6
 	github.com/monnand/dhkx v0.0.0-20180522003156-9e5b033f1ac4
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
@@ -43,7 +44,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/klauspost/compress v1.18.4 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/hash.go
+++ b/hash.go
@@ -63,6 +63,7 @@ func (h HashType) Hasher() (hash.Hash, error) {
 		log.Shared.Warn("md5 is not safe or fast, use sha256 instead")
 		return md5.New(), nil
 	case HashTypeSha1:
+		log.Shared.Warn("sha1 is not safe, use sha256 instead")
 		return sha1.New(), nil
 	case HashTypeSha256:
 		return sha256.New(), nil

--- a/http.go
+++ b/http.go
@@ -40,10 +40,10 @@ func (k CtxKey) String() string {
 }
 
 const (
-	defaultHTTPClientOptTimeout = 30 * time.Second
-	defaultHTTPClientOptMaxConn = 20
+	defaultHTTPClientOptTimeout    = 30 * time.Second
+	defaultHTTPClientOptMaxConn    = 20
 	maxRequestJSONSuccessBodyBytes = 8 * 1024 * 1024
-	maxRequestJSONErrorBodyBytes = 8 * 1024
+	maxRequestJSONErrorBodyBytes   = 8 * 1024
 
 	// HTTPHeaderHost HTTP header name
 	HTTPHeaderHost = "Host"
@@ -568,28 +568,28 @@ func checkRespStatus(c *chaining.Chain) (r any, err error) {
 
 func checkRespErr(maxErrBodyBytes int64) func(c *chaining.Chain) (any, error) {
 	return func(c *chaining.Chain) (any, error) {
-	upErr := c.GetError()
-	if upErr == nil {
-		return c.GetVal(), nil
-	}
+		upErr := c.GetError()
+		if upErr == nil {
+			return c.GetVal(), nil
+		}
 
-	resp, ok := c.GetVal().(*http.Response)
-	if !ok {
-		return nil, errors.Join(upErr, errors.Errorf("got invalid response type `%T`", c.GetVal()))
-	}
+		resp, ok := c.GetVal().(*http.Response)
+		if !ok {
+			return nil, errors.Join(upErr, errors.Errorf("got invalid response type `%T`", c.GetVal()))
+		}
 
-	defer func() { _ = resp.Body.Close() }()
-	respB, truncated, err := readHTTPBodyWithLimit(resp.Body, maxErrBodyBytes)
-	if err != nil {
-		return resp, errors.Wrapf(upErr, "read body got error: %v", err.Error())
-	}
+		defer func() { _ = resp.Body.Close() }()
+		respB, truncated, err := readHTTPBodyWithLimit(resp.Body, maxErrBodyBytes)
+		if err != nil {
+			return resp, errors.Wrapf(upErr, "read body got error: %v", err.Error())
+		}
 
-	suffix := ""
-	if truncated {
-		suffix = " (truncated)"
-	}
+		suffix := ""
+		if truncated {
+			suffix = " (truncated)"
+		}
 
-	return resp, errors.Wrapf(upErr, "got http body%s: %v", suffix, string(respB))
+		return resp, errors.Wrapf(upErr, "got http body%s: %v", suffix, string(respB))
 	}
 }
 


### PR DESCRIPTION
This change improves the security of password-related operations by:
1. Moving the artificial delay (NewDelay) to the very beginning of VerifyHashedPassword and PasswordHash. This ensures that even early returns due to input validation failures (empty password or excessive length) take a consistent amount of time, mitigating timing side-channel attacks.
2. Adding a 4096-character limit to the hashedPassword input in VerifyHashedPassword. This prevents a potential CPU-exhaustion Denial of Service (DoS) attack where a maliciously large string could be provided to be processed by strings.Split and subsequent hex decoding.
3. Adding a security warning when SHA1 is used in the Hasher() function, consistent with the existing MD5 warning.

🚨 Severity: MEDIUM
💡 Vulnerability: Timing side-channel and potential DoS via large input strings.
🎯 Impact: Prevents information leakage via timing and mitigates resource exhaustion risks.
🔧 Fix: Moved delay to function start and added input length validation.
✅ Verification: Verified with 'go test ./...'.

---
*PR created automatically by Jules for task [7025368535790513715](https://jules.google.com/task/7025368535790513715) started by @Laisky*