### PR TITLE
🛡️ Sentinel: [MEDIUM] Add VerifyHMACSha256 for secure HMAC verification

### DIFF
--- a/crypto/sign.go
+++ b/crypto/sign.go
@@ -326,3 +326,25 @@ func HMACSha256(key []byte, data io.Reader) ([]byte, error) {
 
 	return h.Sum(nil), nil
 }
+
+// VerifyHMACSha256 verify HMAC by sha256
+//
+// # Args:
+//   - key: secure key, no limit on length
+//   - data: raw data to verify HMAC
+//   - signature: HMAC signature to verify
+//
+// # Returns:
+//   - err: nil if signature match
+func VerifyHMACSha256(key, signature []byte, data io.Reader) error {
+	h, err := HMACSha256(key, data)
+	if err != nil {
+		return errors.Wrap(err, "calculate hmac")
+	}
+
+	if !hmac.Equal(h, signature) {
+		return errors.New("signature not match")
+	}
+
+	return nil
+}

--- a/crypto/sign_test.go
+++ b/crypto/sign_test.go
@@ -700,3 +700,39 @@ func TestHMAC(t *testing.T) {
 		})
 	}
 }
+
+func TestVerifyHMACSha256(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("secret-key")
+	content := []byte("hello, world")
+
+	t.Run("valid signature", func(t *testing.T) {
+		sig, err := HMACSha256(key, bytes.NewReader(content))
+		require.NoError(t, err)
+
+		err = VerifyHMACSha256(key, sig, bytes.NewReader(content))
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid signature", func(t *testing.T) {
+		err := VerifyHMACSha256(key, []byte("invalid-sig"), bytes.NewReader(content))
+		require.ErrorContains(t, err, "signature not match")
+	})
+
+	t.Run("invalid key", func(t *testing.T) {
+		sig, err := HMACSha256(key, bytes.NewReader(content))
+		require.NoError(t, err)
+
+		err = VerifyHMACSha256([]byte("wrong-key"), sig, bytes.NewReader(content))
+		require.ErrorContains(t, err, "signature not match")
+	})
+
+	t.Run("invalid content", func(t *testing.T) {
+		sig, err := HMACSha256(key, bytes.NewReader(content))
+		require.NoError(t, err)
+
+		err = VerifyHMACSha256(key, sig, bytes.NewReader([]byte("wrong-content")))
+		require.ErrorContains(t, err, "signature not match")
+	})
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Lack of a dedicated HMAC verification function often leads developers to use non-constant-time comparison methods (like bytes.Equal), making the system vulnerable to timing attacks.
🎯 Impact: Attackers might exploit timing differences to recover valid HMAC signatures bit by bit.
🔧 Fix: Implemented VerifyHMACSha256 in crypto/sign.go using crypto/hmac.Equal for secure, constant-time verification.
✅ Verification: Added TestVerifyHMACSha256 in crypto/sign_test.go to verify success and failure cases.

---
*PR created automatically by Jules for task [15182121104108134464](https://jules.google.com/task/15182121104108134464) started by @Laisky*